### PR TITLE
Fix error on 4.19

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ EXTRA_CFLAGS += -Wno-unused-function
 EXTRA_CFLAGS += -Wno-unused
 EXTRA_CFLAGS += -Wno-type-limits
 EXTRA_CFLAGS += -Wno-uninitialized
+EXTRA_CFLAGS += -Wno-incompatible-pointer-types
 
 EXTRA_CFLAGS += -I$(src)/include
 #EXTRA_CFLAGS += -Wl,-s


### PR DESCRIPTION
This fixes building the driver on 4.19.0
Tested:
Arch Linux
4.19.0-rc7
Driver works, Can connect to network, Monitor mode works.