### PR TITLE
os_dep/linux/usb_intf.c : Removing unneeded slashes

### DIFF
--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -153,11 +153,11 @@ static struct usb_device_id rtw_usb_id_tbl[] = {
 	{USB_DEVICE(0x07B8, 0x8179), .driver_info = RTL8188E}, /* TP-Link */
 	{USB_DEVICE(0x0BDA, 0x8179), .driver_info = RTL8188E}, /* Abocom - Abocom */
 	{USB_DEVICE(0x2357, 0x010c), .driver_info = RTL8188E}, /* TP-WL722n v2/v3/v4 */
-	{USB_DEVICE(0x0DF6, 0x0076), .driver_info = RTL8188E}, /* Sitecom N150 v2 */ \
-	{USB_DEVICE(0x2001, 0x330F), .driver_info = RTL8188E}, /* DLink DWA-125 REV D1 */ \
-	{USB_DEVICE(0x2001, 0x3310), .driver_info = RTL8188E}, /* Dlink DWA-123 REV D1 */ \
-	{USB_DEVICE(0x2001, 0x3311), .driver_info = RTL8188E}, /* DLink GO-USB-N150 REV B1 */ \
-	{USB_DEVICE(0x056E, 0x4008), .driver_info = RTL8188E}, /* Elecom WDC-150SU2M */ \		
+	{USB_DEVICE(0x0DF6, 0x0076), .driver_info = RTL8188E}, /* Sitecom N150 v2 */ 
+	{USB_DEVICE(0x2001, 0x330F), .driver_info = RTL8188E}, /* DLink DWA-125 REV D1 */ 
+	{USB_DEVICE(0x2001, 0x3310), .driver_info = RTL8188E}, /* Dlink DWA-123 REV D1 */ 
+	{USB_DEVICE(0x2001, 0x3311), .driver_info = RTL8188E}, /* DLink GO-USB-N150 REV B1 */ 
+	{USB_DEVICE(0x056E, 0x4008), .driver_info = RTL8188E}, /* Elecom WDC-150SU2M */ 	
 #endif
 
 #ifdef CONFIG_RTL8812A


### PR DESCRIPTION
The removed slashes, if present, would trigger a compilation error due to the `#` symbol being treated as stray.

Also, `make install` seems to fail, at least on my machine:
```
root@magister-mentium [0] /usr/src/rtl8188eus # make install 
install -p -m 644 8188eu.ko  /lib/modules/4.19.0-14.1-liquorix-amd64/kernel/drivers/net/wireless/
/sbin/depmod -a 4.19.0-14.1-liquorix-amd64
depmod: ERROR: failed to load symbols from /lib/modules/4.19.0-14.1-liquorix-amd64/updates/dkms/8188eu.ko: Invalid argument
```

I was only able to `insmod` manually.
```
root@magister-mentium [0] /usr/src/rtl8188eus # insmod 8188eu.ko
root@magister-mentium [0] /usr/src/rtl8188eus # lsmod | grep 8188eu
8188eu               1560576  0
cfg80211              757760  6 ath9k_common,ath9k,8188eu,ath,mt7601u,mac80211
root@magister-mentium [0] /usr/src/rtl8188eus # dmesg --follow
<some stuff>
[26272.380064] RTW: module init start
[26272.380066] RTW: rtl8188eu v5.3.9_28540.20180627
[26272.380066] RTW: build time: Feb 12 2019 19:02:57
[26272.380078] RTW: rtw_inetaddr_notifier_register
[26272.380107] usbcore: registered new interface driver rtl8188eu
[26272.380108] RTW: module init ret=0
[26294.434794] usb 2-1.3: new high-speed USB device number 16 using ehci-pci
[26294.540087] usb 2-1.3: New USB device found, idVendor=2357, idProduct=010c, bcdDevice= 0.00
[26294.540096] usb 2-1.3: New USB device strings: Mfr=1, Product=2, SerialNumber=3
[26294.540101] usb 2-1.3: Product: 802.11n NIC
[26294.540105] usb 2-1.3: Manufacturer: Realtek
[26294.540110] usb 2-1.3: SerialNumber: 00E04C0001
<some more verbose thing, should have been less verbose>
```