### PR TITLE
fix arbitrary restriction to inject only packets with length 12 radiotap hdr

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -4286,11 +4286,6 @@ static int rtw_cfg80211_monitor_if_xmit_entry(struct sk_buff *skb, struct net_de
 	if (unlikely(skb->len < rtap_len))
 		goto fail;
 
-	if (rtap_len != 14) {
-		RTW_INFO("radiotap len (should be 14): %d\n", rtap_len);
-		goto fail;
-	}
-
 	/* Skip the ratio tap header */
 	skb_pull(skb, rtap_len);
 


### PR DESCRIPTION
fixes reaver issue https://github.com/t6x/reaver-wps-fork-t6x/issues/279

the loop was added so the abritrary restriction could be removed without the potential of overflowing the dummybuf buffer.

untested, but should work.